### PR TITLE
added axes parameter in homing override

### DIFF
--- a/Firmware/KlackEnderRev2.cfg
+++ b/Firmware/KlackEnderRev2.cfg
@@ -77,6 +77,7 @@ mesh_pps: 4,4
 
 [homing_override]
 set_position_z:0 # Make printer think Z axis is at zero, so we can force a move upwards away from build plate
+axes:z # We only want to override homing the z-axis
 gcode:
     G90
     G1 Z10 F3000 ; move up to prevent accidentally scratching build plate    


### PR DESCRIPTION
otherwise any call to G28 will attempt to do a full home no matter which axes are specified